### PR TITLE
ignore app.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ node_modules/
 #environement variables
 .env
 
+#contains SECRET KEYS IN "extra" property
+app.json
+
 # Expo
 .expo/
 dist/


### PR DESCRIPTION
Below the app.json file with "extra" property that contains firebase keys from firebase config
use "expo-constants" package and see the expo docs

app.json:
{
  "expo": {
    "name": "SnowPatrol",
    "slug": "SnowPatrol",
    "version": "1.0.0",
    "orientation": "portrait",
    "icon": "./assets/images/icon.png",
    "scheme": "myapp",
    "userInterfaceStyle": "automatic",
    "newArchEnabled": true,
    "ios": {
      "supportsTablet": true
    },
    "android": {
      "adaptiveIcon": {
        "foregroundImage": "./assets/images/adaptive-icon.png",
        "backgroundColor": "#ffffff"
      }
    },
    "web": {
      "bundler": "metro",
      "output": "static",
      "favicon": "./assets/images/favicon.png"
    },

    "extra": {
      "apiKey": "your_api_key",
      "authDomain": "your_auth_domain",
      "projectId": "your_project_id",
      "storageBucket": "your_storage_bucket",
      "messagingSenderId": "your_messaging_sender_id",
      "appId": "your_app_id"
    },

    "plugins": [
      "expo-router",
      [
        "expo-splash-screen",
        {
          "image": "./assets/images/splash-icon.png",
          "imageWidth": 200,
          "resizeMode": "contain",
          "backgroundColor": "#ffffff"
        }
      ],

      [
        "expo-font",
        {
          "fonts": ["./assets/fonts/Lato-Thin.ttf"]
        }
      ]


    ],
    "experiments": {
      "typedRoutes": true
    }
  }
}
